### PR TITLE
Taxonomy foundations for a workable prototype

### DIFF
--- a/organisations.md
+++ b/organisations.md
@@ -39,7 +39,7 @@ FHIR has a resource to describe an [Organisation](https://www.hl7.org/fhir/organ
 |↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the organisation.|1|
 |↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|1|
 |`organisationName`|1 (MUST)|String(UTF-8)|Name of the organisation|1|
-|`organisationType`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|1|
+|`organisationType`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|0|
 |`Status`|0, 1 (MUST)|Code: {[WHAT CODES?]}|The status of the organisation's systems - in terms of ability to make and respond to requests via API.|0|
 |`Verification Status`|1 (MUST)|String(UTF-8)|An indication that the organisation's systems have met the required standards in terms of respsonding to requests.|0|
 |`Verfication Date`|0,1 (MUST)|ISO8601: `YYY-MM-DD`|Date of system verification|0|

--- a/organisations.md
+++ b/organisations.md
@@ -33,26 +33,26 @@ Previous work in single view systems has identified the following types of organ
 
 FHIR has a resource to describe an [Organisation](https://www.hl7.org/fhir/organization.html), and we can align with this in some areas. However, we propose the following details are required to facilitate more automated data exchange.
 
-|Field name|Cardinality|Data Type & Format|Description & Reasoning|
-|-----------------------|-----------|------------------|-----------------------|
-|`Identifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the organisation.|
-|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the organisation.|
-|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
-|`Name`|1 (MUST)|String(UTF-8)|Name of the organisation|
-|`Type`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|
-|`Status`|0, 1 (MUST)|Code: {[WHAT CODES?]}|The status of the organisation's systems - in terms of ability to make and respond to requests via API.||
-|`Verification Status`|1 (MUST)|String(UTF-8)|An indication that the organisation's systems have met the required standards in terms of respsonding to requests.|
-|`Verfication Date`|0,1 (MUST)|ISO8601: `YYY-MM-DD`|Date of system verification|
-|`Information Governance`|0, 1 (MUST)|Code: {[WHAT CODES?]}|References to the DPAs or legislation governing data sharing for safeguarding purposes|
+|Field name|Cardinality|Data Type & Format|Description & Reasoning|Priority|
+|-----------------------|-----------|------------------|-----------------------|---------|
+|`organisationIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the organisation.|1|
+|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the organisation.|1|
+|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|1|
+|`organisationName`|1 (MUST)|String(UTF-8)|Name of the organisation|1|
+|`organisationType`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|1|
+|`Status`|0, 1 (MUST)|Code: {[WHAT CODES?]}|The status of the organisation's systems - in terms of ability to make and respond to requests via API.|0|
+|`Verification Status`|1 (MUST)|String(UTF-8)|An indication that the organisation's systems have met the required standards in terms of respsonding to requests.|0|
+|`Verfication Date`|0,1 (MUST)|ISO8601: `YYY-MM-DD`|Date of system verification|0|
+|`Information Governance`|0, 1 (MUST)|Code: {[WHAT CODES?]}|References to the DPAs or legislation governing data sharing for safeguarding purposes|0|
 
 For operations in data exchange, we anticipate a further set of data requirements (not public facing):
 
-|Field name|Cardinality|Data Type & Format|Description & Reasoning|
-|-----------------------|-----------|------------------|-----------------------|
-|`System Provider`|1 (MUST)|String(UTF-8)|Name of the system supplier|
-|`System Version`|1 (MUST)|String(UTF-8)|Name of product and version of system|
-|`Request Test`|1 (MUST)|Code: {[WHAT CODES?]}|Indicator that system passes data request tests satisfactorily|
-|`Response Test`|1 (MUST)|Code: {[WHAT CODES?]}|Indicator that the system responds to requests satisfactorily|
-|`API endpoints`|1 (MUST)|Code: {[WHAT CODES?]}|Operational endpoints for data exchange|
+|Field name|Cardinality|Data Type & Format|Description & Reasoning|Priority|
+|-----------------------|-----------|------------------|-----------------------|---------|
+|`System Provider`|1 (MUST)|String(UTF-8)|Name of the system supplier|0|
+|`System Version`|1 (MUST)|String(UTF-8)|Name of product and version of system|0|
+|`Request Test`|1 (MUST)|Code: {[WHAT CODES?]}|Indicator that system passes data request tests satisfactorily|0|
+|`Response Test`|1 (MUST)|Code: {[WHAT CODES?]}|Indicator that the system responds to requests satisfactorily|0|
+|`API endpoints`|1 (MUST)|Code: {[WHAT CODES?]}|Operational endpoints for data exchange|0|
 
 <a href="https://github.com/SocialCareData/taxonomy/issues/new?template=content_issue.yml&title=Organisations%20Register:%20" class="web-button" target="_blank">Raise an issue about register of organisations</a>

--- a/organisations.md
+++ b/organisations.md
@@ -35,12 +35,12 @@ FHIR has a resource to describe an [Organisation](https://www.hl7.org/fhir/organ
 
 |Field name|Cardinality|Data Type & Format|Description & Reasoning|
 |-----------------------|-----------|------------------|-----------------------|
-|`identifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the organisation.|
+|`Identifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the organisation.|
 |↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the organisation.|
 |↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
-|`name`|1 (MUST)|String(UTF-8)|Name of the organisation|
-|`type`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|
-|`status`|0, 1 (MUST)|Code: {[WHAT CODES?]}|The status of the organisation's systems - in terms of ability to make and respond to requests via API.||
+|`Name`|1 (MUST)|String(UTF-8)|Name of the organisation|
+|`Type`|1 (SHOULD)|Code: {[WHAT CODES?]}|Type of the organisation e.g. Health, Justice, Education - not strictly necessary for the operation of data exchange but convenient in terms of data collection, stakeholder management and information governance.|
+|`Status`|0, 1 (MUST)|Code: {[WHAT CODES?]}|The status of the organisation's systems - in terms of ability to make and respond to requests via API.||
 |`Verification Status`|1 (MUST)|String(UTF-8)|An indication that the organisation's systems have met the required standards in terms of respsonding to requests.|
 |`Verfication Date`|0,1 (MUST)|ISO8601: `YYY-MM-DD`|Date of system verification|
 |`Information Governance`|0, 1 (MUST)|Code: {[WHAT CODES?]}|References to the DPAs or legislation governing data sharing for safeguarding purposes|
@@ -49,9 +49,6 @@ For operations in data exchange, we anticipate a further set of data requirement
 
 |Field name|Cardinality|Data Type & Format|Description & Reasoning|
 |-----------------------|-----------|------------------|-----------------------|
-|`identifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the organisation.|
-|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the organisation.|
-|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
 |`System Provider`|1 (MUST)|String(UTF-8)|Name of the system supplier|
 |`System Version`|1 (MUST)|String(UTF-8)|Name of product and version of system|
 |`Request Test`|1 (MUST)|Code: {[WHAT CODES?]}|Indicator that system passes data request tests satisfactorily|

--- a/organisations_register.json
+++ b/organisations_register.json
@@ -1,0 +1,28 @@
+{
+    "@context": "https://socialcaredata.github.io",
+    "title": "Example Organisation Register",
+    "description": "An example of a register of all data-sharing organisations",
+    "items":[
+        {
+            "organisationIdentifier": {
+                "Identifier Value": "08030289",
+                "Identifier System": "https://find-and-update.company-information.service.gov.uk/company/"
+            }, 
+            "organisationName": "Open Data Institute"
+        },
+        {
+            "organisationIdentifier": {
+                "Identifier Value": "06402143",
+                "Identifier System": "https://find-and-update.company-information.service.gov.uk/company/"
+            }, 
+            "organisationName": "Social Finance"
+        },
+        {
+            "organisationIdentifier": {
+                "Identifier Value": "312278",
+                "Identifier System": "https://register-of-charities.charitycommission.gov.uk/en/charity-search/-/charity-details/"
+            }, 
+            "organisationName": "Coram"
+        }
+    ]
+}

--- a/services.md
+++ b/services.md
@@ -1,34 +1,34 @@
 # Describing a `Service Involvement`
 
-There's two parts to this: defining service providers, and defining a service provider's involvement with a person. The former would be like organisations (organisations is for data sharers/stewards/accessors, whereas services is for practitioners) and the latter would (potentially) resemble one item in a ledger attached to each person, therefore referenced by a person and referencing a service provider.  
+There's two parts to this: defining services, and defining a service's involvement with a person. The former would be like organisations (organisations is for data sharers/stewards/accessors, whereas services is for practitioners) and the latter would (potentially) resemble one item in a ledger attached to each person, therefore referenced by a person and referencing a service provider.  
 
-## Describing a `Service Provider`: specification
+## Describing a `Service`: specification
 
-|Field name|Cardinality|Data Type & Format|Description & Reasoning|
-|----------|-----------|------------------|-----------------------|
-|`serviceIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the service.|
-|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the service.|
-|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
-|`serviceName`|1 (MUST)|String(UTF-8)|Name of the service|
-|`serviceType`|1 (MUST)|Code: {[WHAT CODES?]}|Type of the service|
-|`status`|0, 1 (SHOULD)|Code: {[WHAT CODES?]}|The status of the service provision.|
-|`Contact`|1 (MUST)|**Object**|Contact details TODO|
+|Field name|Cardinality|Data Type & Format|Description & Reasoning|Priority|
+|----------|-----------|------------------|-----------------------|--------|
+|`serviceIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the service.|1|
+|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the service.|1|
+|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|1|
+|`serviceName`|1 (MUST)|String(UTF-8)|Name of the service|1|
+|`serviceType`|1 (MUST)|Code: {[WHAT CODES?]}|Type of the service|0|
+|`status`|0, 1 (SHOULD)|Code: {[WHAT CODES?]}|The status of the service provision.|0|
+|`Contact`|1 (MUST)|**Object**|Contact details TODO|0|
 
 note: no list of practitioners here
 
 
 ## Describing a `Service Involvement`: specification
 
-|Field name|Cardinality|Data Type & Format|Description & Reasoning|
-|----------|-----------|------------------|-----------------------|
-|`involvementIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the specific service involvement.|
-|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the specific service involvement.|
-|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
-|`involvementType`|1 (MUST)|Code: {[WHAT CODES?]}|Nature of the service's involvement or role in the person's social care|
-|`startDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The beginning of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|
-|`endDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The end of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|
-|`Practitioners`|1 (MUST)|**Object**|Practitioners involved TODO|
-|`Further Information`|0 (Should)|**Object**|further info necessary to describe the service involvement TODO|
+|Field name|Cardinality|Data Type & Format|Description & Reasoning|Priority|
+|----------|-----------|------------------|-----------------------|--------|
+|`involvementIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the specific service involvement.|1|
+|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the specific service involvement.|1|
+|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|1|
+|`involvementType`|1 (MUST)|Code: {[WHAT CODES?]}|Nature of the service's involvement or role in the person's social care|0|
+|`startDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The beginning of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|1|
+|`endDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The end of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|1|
+|`Practitioners`|1 (MUST)|**Object**|Practitioners involved TODO|0|
+|`Further Information`|0 (Should)|**Object**|further info necessary to describe the service involvement TODO|0|
 
 note: this is where we start to combine back with placements standard i think
 

--- a/services.md
+++ b/services.md
@@ -1,4 +1,8 @@
-# Describing a `Service Involvement`: Specification
+# Describing a `Service Involvement`
+
+There's two parts to this: defining service providers, and defining a service provider's involvement with a person. The former would be like organisations (organisations is for data sharers/stewards/accessors, whereas services is for practitioners) and the latter would (potentially) resemble one item in a ledger attached to each person, therefore referenced by a person and referencing a service provider.  
+
+## Describing a `Service Provider`: specification
 
 |Field name|Cardinality|Data Type & Format|Description & Reasoning|
 |----------|-----------|------------------|-----------------------|
@@ -7,11 +11,25 @@
 |↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
 |`serviceName`|1 (MUST)|String(UTF-8)|Name of the service|
 |`serviceType`|1 (MUST)|Code: {[WHAT CODES?]}|Type of the service|
+|`status`|0, 1 (SHOULD)|Code: {[WHAT CODES?]}|The status of the service provision.|
+|`Contact`|1 (MUST)|**Object**|Contact details TODO|
+
+note: no list of practitioners here
+
+
+## Describing a `Service Involvement`: specification
+
+|Field name|Cardinality|Data Type & Format|Description & Reasoning|
+|----------|-----------|------------------|-----------------------|
+|`involvementIdentifier`|1, Many (MUST)|**Object**|Unique identifiers (IDs) associated with the specific service involvement.|
+|↳ `Identifier Value`|1 (MUST)|String(UTF-8)|A single unique identifier attached to the specific service involvement.|
+|↳ `Identifier System`|1 (MUST)|URI|A link to the system that the identifier adheres to.|
 |`involvementType`|1 (MUST)|Code: {[WHAT CODES?]}|Nature of the service's involvement or role in the person's social care|
 |`startDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The beginning of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|
 |`endDate`|0, 1 (SHOULD)|Date (ISO8601: `YYY-MM-DD`)|The end of the service provision. The `YYYY-MM-DD` ISO8601 format is the international standard, utilised by the NHS for date records.|
-|`status`|0, 1 (SHOULD)|Code: {[WHAT CODES?]}|The status of the service provision.|
 |`Practitioners`|1 (MUST)|**Object**|Practitioners involved TODO|
-|`Contact`|1 (MUST)|**Object**|Contact details TODO|
+|`Further Information`|0 (Should)|**Object**|further info necessary to describe the service involvement TODO|
+
+note: this is where we start to combine back with placements standard i think
 
 <a href="https://github.com/SocialCareData/person-standard/issues/new?template=content_issue.yml&title=Services:" class="web-button" target="_blank">Raise an issue about Services and Service Involvements</a>

--- a/services_register.json
+++ b/services_register.json
@@ -1,0 +1,28 @@
+{
+    "@context": "https://socialcaredata.github.io",
+    "title": "Example Service Register",
+    "description": "An example of a register of all service providers in the national social care system",
+    "items":[
+        {
+            "serviceIdentifier": {
+                "Identifier Value": "Z8727593",
+                "Identifier System": "https://ico.org.uk/ESDWebPages/Entry/"
+            },
+            "serviceName": "University College London Hospitals NHS Foundation Trust"    
+        },
+        {
+            "serviceIdentifier": {
+                "Identifier Value": "5354482",
+                "Identifier System": "https://find-and-update.company-information.service.gov.uk/company/"
+            },
+            "serviceName": "Imago"    
+        },
+        {
+            "serviceIdentifier": {
+                "Identifier Value": "1090210",
+                "Identifier System": "https://register-of-charities.charitycommission.gov.uk/en/charity-search/-/charity-details/"
+            },
+            "serviceName": "The Avenues Youth Project"    
+        }
+    ]
+}


### PR DESCRIPTION
I worked on turning the organisations and services specifications into example JSON that can be used in the development of a data exchange standard. This included:

* making small adjustments to the organisations spec, and splitting the services spec into two (see text in services.md)
* attaching to each item in each spec a "priority" which indicated whether or not (1 or 0 respectively) I believed that to be necessary for a bare minimum implementation of our peekaboo search use case
* making two JSON files to represent two registers -- one, a register of data sharing organisations, and another a register of service providers

this should give you something to work with for the assembly of a data exchange infra. for me, I need to focus on how service *involvements* are linked to people. that isn't part of the bare minimum peekaboo objectives so I'll delay that. 

